### PR TITLE
fix mobile menu opacity

### DIFF
--- a/components/Hamburger/Hamburger.js
+++ b/components/Hamburger/Hamburger.js
@@ -1,7 +1,7 @@
 import styles from './Hamburger.module.css'
 
 const Hamburger = (props) => (
-    <div className={`${styles.hamburger}  ${props.isOpen ? 'bg-opacity-0' : 'bg-opacity-60'}`}>
+    <div className={styles.hamburger} style={props.isOpen ? { '--tw-bg-opacity': 0 } : { '--tw-bg-opacity': 0.6 }}>
         <input checked={props.isOpen} onChange={props.onChange} type="checkbox" className={styles.hamburgerToggle} />
         <div className={styles.hamburgerContainer}>
             <span className={styles.hamburgerLine} />

--- a/components/Menu/Menu.module.css
+++ b/components/Menu/Menu.module.css
@@ -1,5 +1,5 @@
 .menu {
-    @apply fixed top-0 right-0 py-14 px-3 w-56 bg-white bg-opacity-10 rounded-l-2xl z-20 flex justify-end transition-transform duration-500;
+    @apply fixed top-0 right-0 py-14 px-3 w-56 bg-black bg-opacity-80 rounded-l-2xl z-20 flex justify-end transition-transform duration-500;
 }
 
 #menuLinkList {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
         mono: ['Lekton', ...defaultTheme.fontFamily.mono]
       },
       colors: {
-        orange: 'rgba(255, 121, 0, var(--tw-bg-opacity))'
+        orange: '#ff7900'
       }
     },
     fontFamily: {


### PR DESCRIPTION
hopefully closes #12 
Changed color of menu on mobile to black and reduced opacity.
Fixed the way orange color is generated so it works with every tailwind opacity variable, not only with bg-opacity.